### PR TITLE
Fixed an issue with a trailing slash on Windows + Stop empty directories from being copied

### DIFF
--- a/SublimeSimpleSync.py
+++ b/SublimeSimpleSync.py
@@ -324,7 +324,7 @@ class LocalCopier(threading.Thread, syncCommand):
             # args = [cmd, '/c', 'copy', '/y']
 
             # args = ['copy', '/y']
-            args = ['xcopy', '/y', '/e', '/h']
+            args = ['xcopy', '/y', '/s', '/h']
 
             # folder path
             # print(os.path.split(self.remoteFile)[0])


### PR DESCRIPTION
On Windows, given the following configuration, the update would fail:

{
  "type"     : "local",
  "local"    : "c:\test\test.txt",
  "remote"   : "d:\example"
}

It would try to execute the following commandline:

xcopy /y /e /h c:\temp\test.txt d:\example/\

This is due to a trailing slash on the remoteFile variable which wasn't
getting removed. The fix is to remove any trailing slashes on the
remoteFile variable. This is safe to do, because we always append our own
trailing backslash.
